### PR TITLE
Extend padded length to 256 chars everywhere

### DIFF
--- a/.github/workflows/clingo.yml
+++ b/.github/workflows/clingo.yml
@@ -34,6 +34,7 @@ jobs:
           git clone https://github.com/spack/spack.git spack-src
           . spack-src/share/spack/setup-env.sh
           spack external find --not-buildable cmake bison
+          spack config add "config:install_tree:padded_length:256"
       - name: Install clingo
         run: |
           . spack-src/share/spack/setup-env.sh
@@ -68,6 +69,7 @@ jobs:
           git clone https://github.com/spack/spack.git spack-src
           . spack-src/share/spack/setup-env.sh
           spack external find --not-buildable cmake bison
+          spack config add "config:install_tree:padded_length:256"
       - name: Install clingo
         env:
           PYENV_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/gnupg.yml
+++ b/.github/workflows/gnupg.yml
@@ -44,7 +44,7 @@ jobs:
           . spack-src/share/spack/setup-env.sh
           spack external find --not-buildable gawk perl
           spack config add "config:concretizer:original"
-          spack config add "config:install_tree:padded_length:128"
+          spack config add "config:install_tree:padded_length:256"
           mkdir -p binary-mirror
 
           # Inject flags to have compatibility with MacOSX version 10.13 or higher

--- a/clingo/Dockerfile.manylinux2014
+++ b/clingo/Dockerfile.manylinux2014
@@ -21,7 +21,7 @@ COPY --chown=spack:spack clingo/scripts/create_binary_mirror.sh /home/spack/crea
 RUN ${SPACK_CMD} external find --not-buildable bison 
 RUN ${SPACK_CMD} compiler find
 RUN ${SPACK_CMD} config add "config:concretizer:original"
-RUN ${SPACK_CMD} config add "config:install_tree:padded_length:128"
+RUN ${SPACK_CMD} config add "config:install_tree:padded_length:256"
 
 RUN ${HOME}/bootstrap_clingo2014.sh 36
 RUN ${HOME}/bootstrap_clingo2014.sh 37

--- a/gnupg/Dockerfile.manylinux2014
+++ b/gnupg/Dockerfile.manylinux2014
@@ -15,7 +15,7 @@ RUN ${SPACK_CMD} external find --not-buildable gawk perl
 RUN ${SPACK_CMD} compiler find
 
 RUN ${SPACK_CMD} python -c "import archspec.cpu;print(archspec.cpu.host().family)" > target.txt
-RUN ${SPACK_CMD} -c  "config:install_tree:padded_length:128" install gnupg target=$(cat target.txt)
+RUN ${SPACK_CMD} -c  "config:install_tree:padded_length:256" install gnupg target=$(cat target.txt)
 
 RUN mkdir -p /home/spack/binary-mirror && \
-    ${SPACK_CMD} -c  "config:install_tree:padded_length:128" buildcache create -d /home/spack/binary-mirror -a -u -f gnupg target=$(cat target.txt)
+    ${SPACK_CMD} -c  "config:install_tree:padded_length:256" buildcache create -d /home/spack/binary-mirror -a -u -f gnupg target=$(cat target.txt)

--- a/patchelf/Dockerfile.manylinux2014
+++ b/patchelf/Dockerfile.manylinux2014
@@ -15,7 +15,7 @@ RUN ${SPACK_CMD} external find --not-buildable cmake
 RUN ${SPACK_CMD} compiler find
 
 RUN ${SPACK_CMD} python -c "import archspec.cpu;print(archspec.cpu.host().family)" > target.txt
-RUN ${SPACK_CMD} -c  "config:install_tree:padded_length:128" install patchelf 'ldflags="-static-libstdc++ -static-libgcc"' target=$(cat target.txt)
+RUN ${SPACK_CMD} -c  "config:install_tree:padded_length:256" install patchelf 'ldflags="-static-libstdc++ -static-libgcc"' target=$(cat target.txt)
 
 RUN mkdir -p /home/spack/binary-mirror && \
-    ${SPACK_CMD} -c  "config:install_tree:padded_length:128" buildcache create -d /home/spack/binary-mirror -a -u -f patchelf
+    ${SPACK_CMD} -c  "config:install_tree:padded_length:256" buildcache create -d /home/spack/binary-mirror -a -u -f patchelf

--- a/patchelf/Dockerfile.manylinux2014
+++ b/patchelf/Dockerfile.manylinux2014
@@ -15,7 +15,7 @@ RUN ${SPACK_CMD} external find --not-buildable cmake
 RUN ${SPACK_CMD} compiler find
 
 RUN ${SPACK_CMD} python -c "import archspec.cpu;print(archspec.cpu.host().family)" > target.txt
-RUN ${SPACK_CMD} install patchelf 'ldflags="-static-libstdc++ -static-libgcc"' target=$(cat target.txt)
+RUN ${SPACK_CMD} -c  "config:install_tree:padded_length:128" install patchelf 'ldflags="-static-libstdc++ -static-libgcc"' target=$(cat target.txt)
 
 RUN mkdir -p /home/spack/binary-mirror && \
-    ${SPACK_CMD} buildcache create -d /home/spack/binary-mirror -a -u -f patchelf
+    ${SPACK_CMD} -c  "config:install_tree:padded_length:128" buildcache create -d /home/spack/binary-mirror -a -u -f patchelf


### PR DESCRIPTION
This shouldn't be needed, since the RPATHs in `patchelf` are spuriously added by Spack. But it won't harm either, until we sanitize the RPATH better.