### PR TITLE
Don't Push Build Dependencies to Cache

### DIFF
--- a/.github/workflows/clingo.yml
+++ b/.github/workflows/clingo.yml
@@ -67,7 +67,8 @@ jobs:
           spack external find cmake bison
 
           spack python clingo/install_clingo.py
-          spack buildcache push --unsigned ./binary-mirror clingo-bootstrap
+          spack buildcache push --unsigned --without-build-dependencies \
+            ./binary-mirror clingo-bootstrap
 
       - uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/gnupg.yml
+++ b/.github/workflows/gnupg.yml
@@ -66,7 +66,8 @@ jobs:
           spack config add "packages:all:prefer:[target=$(spack arch --family --target)]"
 
           spack install gnupg
-          spack buildcache push --unsigned ./binary-mirror gnupg
+          spack buildcache push --unsigned --without-build-dependencies \
+            ./binary-mirror gnupg
 
       - uses: actions/upload-artifact@v5
         with:

--- a/clingo/Dockerfile.manylinux2014
+++ b/clingo/Dockerfile.manylinux2014
@@ -38,5 +38,5 @@ RUN export PY_PATH=$(printf '%s' "$PYTHON_VERSION" | \
     awk -F. '{maj=$1; min=$2; suf=(maj*10+min<=37)?"m":""; printf "cp%d%d-cp%d%d%s\n", maj, min, maj, min, suf}') \
     && SPACK_PYTHON=/opt/python/${PY_PATH}/bin/python3 spack python install_clingo.py
 
-RUN spack buildcache push --unsigned ./binary-mirror clingo-bootstrap
-
+RUN spack buildcache push --unsigned --without-build-dependencies \
+      ./binary-mirror clingo-bootstrap

--- a/gnupg/Dockerfile.manylinux2014
+++ b/gnupg/Dockerfile.manylinux2014
@@ -26,4 +26,5 @@ RUN spack config add "config:install_tree:padded_length:256"
 RUN spack config add "packages:all:prefer:[target=$(spack arch --family --target)]"
 
 RUN spack install gnupg
-RUN spack buildcache push --unsigned ./binary-mirror gnupg
+RUN spack buildcache push --unsigned --without-build-dependencies \
+      ./binary-mirror gnupg

--- a/patchelf/Dockerfile.manylinux2014
+++ b/patchelf/Dockerfile.manylinux2014
@@ -25,4 +25,5 @@ RUN spack config add "config:install_tree:padded_length:256"
 RUN spack config add "packages:all:prefer:[target=$(spack arch --family --target)]"
 
 RUN spack install patchelf
-RUN spack buildcache push --unsigned ./binary-mirror patchelf
+RUN spack buildcache push --unsigned --without-build-dependencies \
+      ./binary-mirror patchelf


### PR DESCRIPTION
Not meant to update the v2.2 cache, but should likely be merged before we work on the next bootstrap cache.